### PR TITLE
Updating to Wireshark 3.2.1

### DIFF
--- a/dissector/README.md
+++ b/dissector/README.md
@@ -5,18 +5,22 @@
 * https://www.wireshark.org/docs/wsdg_html_chunked/ChDissectAdd.html
 * https://www.wireshark.org/docs/wsar_html/epan/structtvbuff.html
 
-### Instructions
 
-Download and untar the [Wireshark source code](https://www.wireshark.org/download.html). Only tested on Wireshark 2.4.0 for now.
+### Instructions
+Download and untar the [Wireshark source code](https://www.wireshark.org/download.html). Only tested on Wireshark 3.2.1 for now.
+
+We assume that `wireshark-3.2.1` is located in `~/wireshark-3.2.1/` and `wireshark-dissector-rs` is located in `~/wireshark-dissector-rs`.
+
 
 ```shell
-$ pwd
-wireshark-dissector-rs
+$ cd ~/wireshark-dissector-rs
 $ cd dissector/plugins/dummy/ && make -f ./Makefile.rust && cd -
-$ cp -r ./dissector/plugins /path/to/wireshark-2.4.0
-$ cd /path/to/wireshsark-2.4.0
-$ ./autogen.sh
-$ make -C plugins
+$ cp -r ./dissector/plugins/dummy ~/wireshark-3.2.1/plugins/epan/
+$ cd ~/wireshark-3.2.1
+$ mkdir build
+$ cd ~/wireshark-3.2.1/build
+# include our plugin directory
+$ cmake .. -DCUSTOM_PLUGIN_SRC_DIR="plugins/epan/dummy"
 $ make
 $ sudo make install
 ```
@@ -24,22 +28,27 @@ $ sudo make install
 After the long first compile where `wireshark` is built, simply rebuilding the plugins is enough if you change your dissector later:
 
 ```shell
-$ ./autogen.sh
-$ make -C plugins
+$ cd ~/wireshark-3.2.1/build
+$ cp -r ./dissector/plugins/dummy ~/wireshark-3.2.1/plugins/epan/
+$ make plugins
+$ sudo make install
 ```
 
-Also, you must modify `wireshark-2.4.0/epan/Makefile.am` to include `dummy`:
+### Development Notes
+There are several resources available:
+
+* Instructions of plugin development: https://github.com/wireshark/wireshark/blob/master/doc/README.plugins
+* Example of a simple plugin: https://github.com/wireshark/wireshark/tree/master/doc/plugins.example
+* More complex plugins: https://github.com/wireshark/wireshark/tree/master/plugins/epan
+
+You may need to re-generate `plugin.c` when you edit `packet-dummy.c` or `packet-dummy.h`:
 
 ```shell
-if ENABLE_STATIC
--include ../plugins/Custom.make
-plugin_src = \
-        ...
-        ../plugins/gryphon/packet-gryphon.c \
-        ../plugins/gryphon/plugin.c \
-        ../plugins/dummy/plugin.c \
-        ../plugins/dummy/packet-dummy.c \
-        ...
+$ cd ~/wireshark-dissector-rs/dissector/plugins/dummy/
+$ ~/wireshark-3.2.1/tools/make-plugin-reg.py \
+        # args: 
+        # 1st: /path/to/wireshark-dissector-rs/dissector/plugins/dummy/
+        # 2nd: plugin
+        # rest: list of your source codes
+        $PWD plugin packet-dummy.c packet-dummy.h
 ```
-
-Without this step (although I couldn't find it in any online tutorials), `wireshark` fails to start with `unrecognized symbol` (i.e. couldn't link to `dummy.so`).

--- a/dissector/plugins/dummy/CMakeLists.txt
+++ b/dissector/plugins/dummy/CMakeLists.txt
@@ -40,23 +40,16 @@ set(CLEAN_FILES
 set_source_files_properties(
         ${CLEAN_FILES}
         PROPERTIES
-        COMPILE_FLAGS ${WERROR_COMMON_FLAGS}
+        COMPILE_FLAGS "${WERROR_COMMON_FLAGS}"
 )
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
-register_dissector_files(plugin.c
-	plugin
-	${DISSECTOR_SRC}
-)
+add_plugin_library(dummy epan)
 
-add_plugin_library(dummy)
+target_link_libraries(dummy epan "${CMAKE_CURRENT_SOURCE_DIR}/libdummy_dissector.a")
 
-install(TARGETS dummy
-	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/${CPACK_PACKAGE_NAME}/plugins/${CPACK_PACKAGE_VERSION} NAMELINK_SKIP
-	RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}/${CPACK_PACKAGE_NAME}/plugins/${CPACK_PACKAGE_VERSION}
-	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/${CPACK_PACKAGE_NAME}/plugins/${CPACK_PACKAGE_VERSION}
-)
+install_plugin(dummy epan)
 
 file(GLOB DISSECTOR_HEADERS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "*.h")
 CHECKAPI(

--- a/dissector/plugins/dummy/plugin.c
+++ b/dissector/plugins/dummy/plugin.c
@@ -1,40 +1,33 @@
 /*
  * Do not modify this file. Changes will be overwritten.
  *
- * Generated automatically from ../../tools/make-dissector-reg.py.
+ * Generated automatically from /Users/kyosuke/wireshark-3.2.1/tools/make-plugin-reg.py.
  */
 
 #include "config.h"
 
 #include <gmodule.h>
 
-#include "moduleinfo.h"
-
 /* plugins are DLLs */
 #define WS_BUILD_DLL
 #include "ws_symbol_export.h"
 
-#ifndef ENABLE_STATIC
-WS_DLL_PUBLIC_DEF void plugin_register (void);
-WS_DLL_PUBLIC_DEF const gchar version[] = VERSION;
+#include "epan/proto.h"
 
-/* Start the functions we need for the plugin stuff */
+void proto_register_dummy(void);
+void proto_reg_handoff_dummy(void);
 
-extern void proto_register_dummy(void);
+WS_DLL_PUBLIC_DEF const gchar plugin_version[] = PLUGIN_VERSION;
+WS_DLL_PUBLIC_DEF const int plugin_want_major = VERSION_MAJOR;
+WS_DLL_PUBLIC_DEF const int plugin_want_minor = VERSION_MINOR;
 
-WS_DLL_PUBLIC_DEF void
-plugin_register (void)
+WS_DLL_PUBLIC void plugin_register(void);
+
+void plugin_register(void)
 {
-    proto_register_dummy();
+    static proto_plugin plug_dummy;
+
+    plug_dummy.register_protoinfo = proto_register_dummy;
+    plug_dummy.register_handoff = proto_reg_handoff_dummy;
+    proto_register_plugin(&plug_dummy);
 }
-
-WS_DLL_PUBLIC_DEF void plugin_reg_handoff(void);
-
-extern void proto_reg_handoff_dummy(void);
-
-WS_DLL_PUBLIC_DEF void
-plugin_reg_handoff(void)
-{
-    proto_reg_handoff_dummy();
-}
-#endif


### PR DESCRIPTION
I tested the dummy dissector on Wireshark 3.2.1. I found some files need to be fixed:
- CMakeLists.txt
- plugin.c (auto-generated by `wireshark/tools/make-plugin-reg.py`)

I also updated dissector/README.md to explain how to build the dissector with Wireshark 3.2.1.